### PR TITLE
Fix shell usage for proxy user during setup

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -86,7 +86,7 @@ main() {
 
     sudo chown -R "$proxy_user_name:$proxy_user_name" "$tmpdir"
     
-    (sudo su - $proxy_user_name && {
+    (sudo su - --shell=/bin/bash $proxy_user_name && {
          keysadded=0
          for filename in "$tmpdir"/*.pub; do
              if [[ -f $filename ]]; then


### PR DESCRIPTION
If the user is configured with no shell, we can't just `sudo su - [user]`. So select `/bin/bash` explicitly.